### PR TITLE
Automate and update release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The full semantic version (e.g., 1.2.3)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update package.json Version
+        run: |
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+          git add package.json package-lock.json
+          git commit -m "Update version to ${{ github.event.inputs.version }}"
+          git push origin HEAD
+
+      - name: Extract Major Version
+        id: extract_major
+        run: |
+          MAJOR_VERSION=$(echo "${{ github.event.inputs.version }}" | cut -d'.' -f1)
+          echo "major=v${MAJOR_VERSION}" >> $GITHUB_ENV
+
+      - name: Check if Version Tag Exists
+        id: check_version_tag
+        run: |
+          if git rev-parse "v${{ github.event.inputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ github.event.inputs.version }} already exists!"
+            exit 1
+          fi
+
+      - name: Create Specific Version Tag
+        run: |
+          VERSION="v${{ github.event.inputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create or Update Major Tag
+        run: |
+          MAJOR="${{ env.major }}"
+          git tag -f "$MAJOR"
+          git push origin "$MAJOR" --force
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ github.event.inputs.version }}"
+          name: "v${{ github.event.inputs.version }}"
+          draft: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ioki-mobility/summaraizer-action/blob/main/LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/ioki-mobility/summaraizer-action?include_prereleases)](https://github.com/ioki-mobility/summaraizer-action/releases/latest)
 
 # summaraizer GitHub Action
 
@@ -24,7 +25,7 @@ jobs:
       issues: write
     steps:
     - name: Summarize
-      uses: ioki-mobility/summaraizer-action@main
+      uses: ioki-mobility/summaraizer-action@{latestRelease or main}
       with:
         provider: 'ollama'
         provider-args: '--url https://ollama.example.com --model llama3.1'
@@ -72,8 +73,9 @@ The arguments for the choosen provider. Checkout the [summaraizer documentation]
 
 ## Release
 
-1. Checkout the repo (`git clone ...`)
-2. Install `npm`
-3. Run `npm install`
-4. Run `npm run build`
-5. Push to the repo
+1. Navigate to the [Actions tab](../../actions) in your repository.
+2. Select the ["Create Release" workflow](../../actions/workflows/release.yml).
+3. Click on "Run workflow" and enter the new version number (e.g., `1.2.3`).
+
+The new version tag will be created as well as the **major** tag will be created or updated.
+Also a draft GitHub release will be generated. You can view the releases on the [Releases page](../../releases/latest).


### PR DESCRIPTION
This pull request introduces a new workflow for creating releases and updates the documentation to reflect these changes. The most important changes include adding a GitHub Actions workflow for release creation, updating the `README.md` to include a badge for GitHub releases, and modifying the release instructions.

### Workflow and Documentation Updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R68): Added a new GitHub Actions workflow to automate the release creation process, including steps for version tagging and GitHub release creation.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2): Added a GitHub Release badge to the documentation to display the latest release version.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28): Updated the usage example to use the latest release or main branch for the `summaraizer-action`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R81): Revised the release instructions to use the new GitHub Actions workflow for creating releases.